### PR TITLE
Use hash for instant set key

### DIFF
--- a/lib/red_blocks/instant_set.rb
+++ b/lib/red_blocks/instant_set.rb
@@ -2,15 +2,13 @@ module RedBlocks
   class InstantSet < RedBlocks::Set
     attr_reader :value, :suffix
 
-    RAND_MAX = 100_000_000
-
     def initialize(value)
       unless value.is_a?(Array)
         raise TypeError.new("Expect value as Array, but got #{ids_or_ids_with_scores.class}")
       end
 
       @value = value
-      @suffix = rand(RAND_MAX)
+      @suffix = Digest::SHA2.hexdigest value.join(",")
     end
 
     def cache_time

--- a/lib/red_blocks/instant_set.rb
+++ b/lib/red_blocks/instant_set.rb
@@ -8,7 +8,7 @@ module RedBlocks
       end
 
       @value = value
-      @suffix = Digest::SHA2.hexdigest value.join(",")
+      @suffix = Digest::SHA2.hexdigest value.sort.uniq.join(",")
     end
 
     def cache_time

--- a/spec/red_blocks/instant_set_spec.rb
+++ b/spec/red_blocks/instant_set_spec.rb
@@ -21,9 +21,8 @@ describe RedBlocks::InstantSet do
 
   describe '#key_suffix' do
     context 'when value is ids' do
-      let(:value) { [1,2,3] }
-      let(:instant_set1) { RedBlocks::InstantSet.new(value) }
-      let(:instant_set2) { RedBlocks::InstantSet.new(value.reverse) }
+      let(:instant_set1) { RedBlocks::InstantSet.new([1,2,3]) }
+      let(:instant_set2) { RedBlocks::InstantSet.new([1,2,3,4]) }
 
       it 'return value' do
         expect(instant_set1.key_suffix).not_to eq instant_set2.key_suffix
@@ -32,8 +31,8 @@ describe RedBlocks::InstantSet do
 
     context 'when value is id_with_scores' do
       let(:value) { [[1, 1], [2, 2], [3, 3]] }
-      let(:instant_set1) { RedBlocks::InstantSet.new(value) }
-      let(:instant_set2) { RedBlocks::InstantSet.new(value.reverse) }
+      let(:instant_set1) { RedBlocks::InstantSet.new([[1, 1], [2, 2], [3, 3]]) }
+      let(:instant_set2) { RedBlocks::InstantSet.new([[1, 0], [2, 2], [3, 3]]) }
 
       it 'return value' do
         expect(instant_set1.key_suffix).not_to eq instant_set2.key_suffix

--- a/spec/red_blocks/instant_set_spec.rb
+++ b/spec/red_blocks/instant_set_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe RedBlocks::InstantSet do
+  describe '#get' do
+    context 'when value is ids' do
+      let(:value) { [1,2,3,4,5] }
+
+      it 'return value' do
+        expect(RedBlocks::InstantSet.new(value).get).to eq value
+      end
+    end
+
+    context 'when value is id_with_scores' do
+      let(:value) { [[1, 1], [2,2]] }
+
+      it 'return value' do
+        expect(RedBlocks::InstantSet.new(value).get).to eq value
+      end
+    end
+  end
+
+  describe '#key_suffix' do
+    context 'when value is ids' do
+      let(:value) { [1,2,3] }
+      let(:instant_set1) { RedBlocks::InstantSet.new(value) }
+      let(:instant_set2) { RedBlocks::InstantSet.new(value.reverse) }
+
+      it 'return value' do
+        expect(instant_set1.key_suffix).not_to eq instant_set2.key_suffix
+      end
+    end
+
+    context 'when value is id_with_scores' do
+      let(:value) { [[1, 1], [2, 2], [3, 3]] }
+      let(:instant_set1) { RedBlocks::InstantSet.new(value) }
+      let(:instant_set2) { RedBlocks::InstantSet.new(value.reverse) }
+
+      it 'return value' do
+        expect(instant_set1.key_suffix).not_to eq instant_set2.key_suffix
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why
The key of `InstantSet` is random regardless of value. 
As a result, the result of `Intersection` that includes` InstantSet` is not cached at all and wastes Redis memory.
I want to avoid it.

## What
- [x] Do not use `rand`, use `Digest`
