### PR TITLE
Relax version constraint for redis gem

### DIFF
--- a/red_blocks.gemspec
+++ b/red_blocks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency "redis", "~> 3.3"
+  spec.add_dependency "redis", ">= 3.3", "< 5.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
[redis gem 4.0 has been released in August 2017](https://rubygems.org/gems/redis/versions). It's time to upgrade red_blocks dependency on it!

From its [CHANGELOG](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md), I don't see anything breaks RedBlocks. For your reference, here are places where it uses redis:

<details>

```
$ ag "RedBlocks\.client"
spec/spec_helper.rb
8:  client_proc: -> { MockRedis.new }, # Replace to `RedBlocks.client` if you want to test on a real Redis.

spec/red_blocks/composed_set_spec.rb
70:      RedBlocks.client.del(key1)
71:      RedBlocks.client.del(key2)

spec/red_blocks/intersection_set_spec.rb
34:    RedBlocks.client.del(key1)
35:    RedBlocks.client.del(key2)
40:      expect(RedBlocks.client).to receive(:zinterstore)
48:      expect(RedBlocks.client.zrevrange(set.key, 0, -1)).to eq(['2', '3', RedBlocks.config.blank_id.to_s])
55:      expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["2", 4.2], ["3", 4.0], [RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity * 2]])
62:      expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["2", 0.2], ["3", 0.0], [RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
69:      expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["3", 4.0], ["2", 4.0], [RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
75:      expect(RedBlocks.client.zrevrange(blank_set.key, 0, -1, with_scores: true)).to eq([[RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
81:      RedBlocks.client.del(key1)
82:      RedBlocks.client.del(key2)

spec/red_blocks/set_spec.rb
30:    RedBlocks.client.del(set.key)
41:      expect(RedBlocks.client.zrange(set.key, 0, -1)).to eq([RedBlocks.config.blank_id, 1, 2, 3].map(&:to_s))
50:      expect(RedBlocks.client.zrange(set.key, 0, -1)).to eq([RedBlocks.config.blank_id, 2, 1, 3].map(&:to_s))
89:      allow(RedBlocks.client).to receive(:ttl).and_return(RedBlocks.config.intermediate_set_lifetime - 1)
94:      allow(RedBlocks.client).to receive(:ttl).and_return(RedBlocks.config.intermediate_set_lifetime + 1)

lib/red_blocks/set.rb
9:      RedBlocks.client.pipelined do
10:        RedBlocks.client.zrem(key, removed_ids) if removed_ids.size > 0
11:        RedBlocks.client.zadd(key, entries)
12:        RedBlocks.client.expire(key, expiration_time)
21:    def disabled?(ttl = RedBlocks.client.ttl(key))
31:      res = RedBlocks.client.zrevrange(key, paginator.head, paginator.tail, with_scores: with_scores)
49:      RedBlocks.client.zcard(key) - 1 # Discount the blank entry.
106:      score = self.disabled? ? nil : (RedBlocks.client.zscore(key, id) || 0)

lib/red_blocks/operations.rb
6:    RedBlocks.client.pipelined do
8:        RedBlocks.client.del(key)
28:        RedBlocks.client.del(set.key)
36:        RedBlocks.client.del(set.key)
48:      cursor, keys = RedBlocks.client.scan(cursor, match: pattern, count: 1000)

lib/red_blocks/composed_set.rb
31:      RedBlocks.client.expire(key, expiration_time)
49:      ttls = RedBlocks.client.pipelined do
50:        @sets.each { |set| RedBlocks.client.ttl(set.key) }

lib/red_blocks/union_set.rb
8:        RedBlocks.client.zunionstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
10:        RedBlocks.client.pipelined do
11:          RedBlocks.client.del(key)
12:          RedBlocks.client.zadd(key, normalize_entries([]))

lib/red_blocks/intersection_set.rb
8:        RedBlocks.client.zinterstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
10:        RedBlocks.client.pipelined do
11:          RedBlocks.client.del(key)
12:          RedBlocks.client.zadd(key, normalize_entries([]))

spec/red_blocks_spec.rb
13:    expect(RedBlocks.client).to be_a(MockRedis)

lib/red_blocks.rb
7:        client_proc: -> { RedBlocks.client },

lib/red_blocks/subtraction_set.rb
23:      RedBlocks.client.zunionstore(key, [set1.key])
24:      RedBlocks.client.zrem(key, set2.ids(paginator: RedBlocks::Paginator.all))
25:      RedBlocks.client.expire(key, expiration_time)
43:      ttls = RedBlocks.client.pipelined do
44:        sets.each { |set| RedBlocks.client.ttl(set.key) }

spec/red_blocks/union_set_spec.rb
34:    RedBlocks.client.del(key1)
35:    RedBlocks.client.del(key2)
40:      expect(RedBlocks.client).to receive(:zunionstore)
48:      expect(RedBlocks.client.zrevrange(set.key, 0, -1)).to eq(['2', '3', '1', '9', RedBlocks.config.blank_id.to_s])
55:      expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["2", 4.2], ["3", 4.0], ["1", 0.5], ["9", -4.0], [RedBlocks.config.blank_id.to_s, -2 *RedBlocks.config.infinity]])
62:      expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["1", 0.5], ["2", 0.2], ["3", 0.0], ["9", -4.0], [RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
69:      expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["3", 4.0], ["2", 4.0], ["1", 0.5], ["9", -4.0], [RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
75:      expect(RedBlocks.client.zrevrange(blank_set.key, 0, -1, with_scores: true)).to eq([[RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
81:      RedBlocks.client.del(key1)
82:      RedBlocks.client.del(key2)
```

</details>

