### PR TITLE
Make ComposedSet#update! safe to Redis connection lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v0.1.6 / 2022-09-02
+- Make ComposedSet#update! safe to Redis connection lost by @stomk https://github.com/Altech/red_blocks/pull/12
+
 ### v0.1.0 / 2017-12-05
 
 First release.

--- a/lib/red_blocks/composed_set.rb
+++ b/lib/red_blocks/composed_set.rb
@@ -27,8 +27,10 @@ module RedBlocks
 
     def update!
       disabled_sets.each(&:update!)
-      compose_sets!
-      RedBlocks.client.expire(key, expiration_time)
+      RedBlocks.client.pipelined do
+        compose_sets!
+        RedBlocks.client.expire(key, expiration_time)
+      end
     end
 
     def cache_time

--- a/lib/red_blocks/intersection_set.rb
+++ b/lib/red_blocks/intersection_set.rb
@@ -7,10 +7,8 @@ module RedBlocks
       if sets.size > 0
         RedBlocks.client.zinterstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
       else
-        RedBlocks.client.pipelined do
-          RedBlocks.client.del(key)
-          RedBlocks.client.zadd(key, normalize_entries([]))
-        end
+        RedBlocks.client.del(key)
+        RedBlocks.client.zadd(key, normalize_entries([]))
       end
     end
   end

--- a/lib/red_blocks/union_set.rb
+++ b/lib/red_blocks/union_set.rb
@@ -7,10 +7,8 @@ module RedBlocks
       if sets.size > 0
         RedBlocks.client.zunionstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
       else
-        RedBlocks.client.pipelined do
-          RedBlocks.client.del(key)
-          RedBlocks.client.zadd(key, normalize_entries([]))
-        end
+        RedBlocks.client.del(key)
+        RedBlocks.client.zadd(key, normalize_entries([]))
       end
     end
   end

--- a/lib/red_blocks/version.rb
+++ b/lib/red_blocks/version.rb
@@ -1,3 +1,3 @@
 module RedBlocks
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
## Why
https://github.com/wantedly/infrastructure/issues/11193#issuecomment-1234008740

ComposedSet (UnionSet, IntersectionSet の親クラス) の #update! は zunionstore / zintersectionstore 操作とキーへの新たな expire の設定の操作が pipeline 化されていない。
そのため、その操作間で Redis の接続が切れたら、生存期間が設定されないキーが作られてしまう。

ElastiCache のバージョンアップ作業で Redis の接続が切れる時間が発生することが想定されているので、このような不整合が起きないようにしたい。

## What

ComposedSet の #update! で zunionstore / zintersectionstore 操作とキーへの新たな expire の設定の操作とを pipeline に含めるようにする。