### PR TITLE
Make compatible to redis gem 5 series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v0.1.7 / 2023-06-21
+- Make compatible to redis gem 5 series @KeiSakam https://github.com/Altech/red_blocks/pull/13
+
 ### v0.1.6 / 2022-09-02
 - Make ComposedSet#update! safe to Redis connection lost by @stomk https://github.com/Altech/red_blocks/pull/12
 

--- a/lib/red_blocks/composed_set.rb
+++ b/lib/red_blocks/composed_set.rb
@@ -27,9 +27,9 @@ module RedBlocks
 
     def update!
       disabled_sets.each(&:update!)
-      RedBlocks.client.pipelined do
+      RedBlocks.client.pipelined do |pipeline|
         compose_sets!
-        RedBlocks.client.expire(key, expiration_time)
+        pipeline.expire(key, expiration_time)
       end
     end
 
@@ -48,8 +48,8 @@ module RedBlocks
     end
 
     def disabled_sets
-      ttls = RedBlocks.client.pipelined do
-        @sets.each { |set| RedBlocks.client.ttl(set.key) }
+      ttls = RedBlocks.client.pipelined do |pipeline|
+        @sets.each { |set| pipeline.ttl(set.key) }
       end
       @sets.zip(ttls).select do |set, ttl|
         set.disabled?(ttl)

--- a/lib/red_blocks/composed_set.rb
+++ b/lib/red_blocks/composed_set.rb
@@ -28,7 +28,7 @@ module RedBlocks
     def update!
       disabled_sets.each(&:update!)
       RedBlocks.client.pipelined do |pipeline|
-        compose_sets!
+        compose_sets!(pipeline)
         pipeline.expire(key, expiration_time)
       end
     end
@@ -43,7 +43,7 @@ module RedBlocks
 
     private
 
-    def compose_sets!
+    def compose_sets!(pipeline)
       raise NotImplementedError
     end
 

--- a/lib/red_blocks/intersection_set.rb
+++ b/lib/red_blocks/intersection_set.rb
@@ -2,13 +2,13 @@ module RedBlocks
   class IntersectionSet < ComposedSet
     private
 
-    def compose_sets!
+    def compose_sets!(pipeline)
       sets = @sets.to_a
       if sets.size > 0
-        RedBlocks.client.zinterstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
+        pipeline.zinterstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
       else
-        RedBlocks.client.del(key)
-        RedBlocks.client.zadd(key, normalize_entries([]))
+        pipeline.del(key)
+        pipeline.zadd(key, normalize_entries([]))
       end
     end
   end

--- a/lib/red_blocks/operations.rb
+++ b/lib/red_blocks/operations.rb
@@ -3,9 +3,9 @@
 module RedBlocks::Operations
   def self.delete(set_or_pattern)
     keys = self.keys(set_or_pattern)
-    RedBlocks.client.pipelined do
+    RedBlocks.client.pipelined do |pipeline|
       keys.each do |key|
-        RedBlocks.client.del(key)
+        pipeline.del(key)
       end
     end
   end

--- a/lib/red_blocks/set.rb
+++ b/lib/red_blocks/set.rb
@@ -6,10 +6,10 @@ module RedBlocks
     def update!(get_result = self.get)
       entries = normalize_entries(validate_entries!(get_result))
       removed_ids = self.ids(paginator: Paginator.all, update_if_disabled: false) - entries.map(&:last)
-      RedBlocks.client.pipelined do
-        RedBlocks.client.zrem(key, removed_ids) if removed_ids.size > 0
-        RedBlocks.client.zadd(key, entries)
-        RedBlocks.client.expire(key, expiration_time)
+      RedBlocks.client.pipelined do |pipeline|
+        pipeline.zrem(key, removed_ids) if removed_ids.size > 0
+        pipeline.zadd(key, entries)
+        pipeline.expire(key, expiration_time)
       end
       nil
     end

--- a/lib/red_blocks/subtraction_set.rb
+++ b/lib/red_blocks/subtraction_set.rb
@@ -40,8 +40,8 @@ module RedBlocks
     private
 
     def disabled_sets
-      ttls = RedBlocks.client.pipelined do
-        sets.each { |set| RedBlocks.client.ttl(set.key) }
+      ttls = RedBlocks.client.pipelined do |pipeline|
+        sets.each { |set| pipeline.ttl(set.key) }
       end
       sets.zip(ttls).select do |set, ttl|
         set.disabled?(ttl)

--- a/lib/red_blocks/union_set.rb
+++ b/lib/red_blocks/union_set.rb
@@ -2,13 +2,13 @@ module RedBlocks
   class UnionSet < ComposedSet
     private
 
-    def compose_sets!
+    def compose_sets!(pipeline)
       sets = @sets.to_a
       if sets.size > 0
-        RedBlocks.client.zunionstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
+        pipeline.zunionstore(key, sets.map(&:key), weights: sets.map(&:weight), aggregate: score_func)
       else
-        RedBlocks.client.del(key)
-        RedBlocks.client.zadd(key, normalize_entries([]))
+        pipeline.del(key)
+        pipeline.zadd(key, normalize_entries([]))
       end
     end
   end

--- a/lib/red_blocks/version.rb
+++ b/lib/red_blocks/version.rb
@@ -1,3 +1,3 @@
 module RedBlocks
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/red_blocks.gemspec
+++ b/red_blocks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency "redis", ">= 3.3"
+  spec.add_dependency "redis", ">= 3.3", "< 6.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/red_blocks.gemspec
+++ b/red_blocks.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency "redis", ">= 3.3", "< 5.0"
+  spec.add_dependency "redis", ">= 3.3"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/red_blocks/union_set_spec.rb
+++ b/spec/red_blocks/union_set_spec.rb
@@ -25,11 +25,6 @@ describe RedBlocks::UnionSet do
     RedBlocks::UnionSet.new([klass1.new, klass2.new])
   }
 
-  let(:blank_set) {
-    enum = Enumerator.new { |y| }
-    RedBlocks::UnionSet.new(enum)
-  }
-
   before do
     RedBlocks.client.del(key1)
     RedBlocks.client.del(key2)
@@ -37,7 +32,7 @@ describe RedBlocks::UnionSet do
 
   describe '#update!' do
     it 'executes zunionstore' do
-      expect(RedBlocks.client).to receive(:zunionstore)
+      expect_any_instance_of(MockRedis::PipelinedWrapper).to receive(:zunionstore)
 
       set.update!
     end
@@ -69,24 +64,17 @@ describe RedBlocks::UnionSet do
       expect(RedBlocks.client.zrevrange(set.key, 0, -1, with_scores: true)).to eq([["3", 4.0], ["2", 4.0], ["1", 0.5], ["9", -4.0], [RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
     end
 
-    it 'stores blank data' do
-      blank_set.update!
+    context 'update! blank_set' do
+      let(:blank_set) {
+        enum = Enumerator.new { |y| }
+        RedBlocks::UnionSet.new(enum)
+      }
 
-      expect(RedBlocks.client.zrevrange(blank_set.key, 0, -1, with_scores: true)).to eq([[RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
-    end
-  end
+      it 'stores blank data' do
+        blank_set.update!
 
-  describe '#ids' do
-    it 'returns all disabled sets' do
-      RedBlocks.client.del(key1)
-      RedBlocks.client.del(key2)
-      expect(set.send(:disabled_sets).size).to eq(2)
-
-      set.sets.each do |set|
-        set.update!
+        expect(RedBlocks.client.zrevrange(blank_set.key, 0, -1, with_scores: true)).to eq([[RedBlocks.config.blank_id.to_s, -RedBlocks.config.infinity]])
       end
-
-      expect(set.send(:disabled_sets).size).to eq(0)
     end
   end
 end


### PR DESCRIPTION
### Why
Redis#pipelined (and Redis#multi) must be called on the block argument in redis gem to 5 series.

https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#500

> Removed the deprecated pipelined and multi signature. Commands now MUST be called on the block argument, not the original redis instance.


### What
Fix to call `pipelined`(the receiver is assumed to Redis instance) on the block arguments.


### Check

- [x] All usecases of `pipelined` have been fixed.
- [x] `multi` is not used originally in this gem.

<img width="1125" alt="image" src="https://github.com/Altech/red_blocks/assets/53637056/456f2397-ab1f-4c98-a7a1-c3c942e1011b">


### TODO

- [ ] Add commit to fix version from 0.1.6 to 0.1.7 after approval of this PR
